### PR TITLE
Improve accel example to also use first pixel

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ while (true) {
     let x = input.acceleration(Dimension.X) / 2;
     let y = input.acceleration(Dimension.Y) / 2;
     let z = input.acceleration(Dimension.Z) / 2;
-    strip.setPixelColor(0, neopixel.rgb(x, y, -z));
     strip.shift(1);
+    strip.setPixelColor(0, neopixel.rgb(x, y, -z));
     strip.show();
     basic.pause(100);
 }


### PR DESCRIPTION
The previous version was colouring the first pixel then shifting by one before showing.
As a result the first pixel was always unused (blank-filled by shift()).
Instead, we now shift by one, THEN set the first pixel colour, then show.